### PR TITLE
feat: add the ability to control which buffers highlights are applied to

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,8 @@ opts = {
     -- By default, visimatch will highlight text even if it doesn't have exactly
     -- the same spacing as the selected region. You can set this to `true` if
     -- you're not a fan of this behaviour :)
-    strict_spacing = false,    -- Visible buffers which should be highlighted. Valid options:
+    strict_spacing = false,
+    -- Visible buffers which should be highlighted. Valid options:
     -- * `"filetype"` (the default): highlight buffers with the same filetype
     -- * `"current"`: highlight matches in the current buffer only
     -- * `"all"`: highlight matches in all visible buffers

--- a/README.md
+++ b/README.md
@@ -33,7 +33,11 @@ opts = {
     -- By default, visimatch will highlight text even if it doesn't have exactly
     -- the same spacing as the selected region. You can set this to `true` if
     -- you're not a fan of this behaviour :)
-    strict_spacing = false
+    strict_spacing = false,    -- Visible buffers which should be highlighted. Valid options:
+    -- * `"filetype"` (the default): highlight buffers with the same filetype
+    -- * `"current"`: highlight matches in the current buffer only
+    -- * `"all"`: highlight matches in all visible buffers
+    buffers = "filetype"
 }
 ```
 


### PR DESCRIPTION
Adds a `buffers` option to the default config

``` lua
local config = {
    hl_group = "Search",
    chars_lower_limit = 6,
    lines_upper_limit = 30,
    strict_spacing = false,
    -- Visible buffers which should be highlighted. Valid options:
    -- * `"filetype"` (the default): highlight buffers with the same filetype
    -- * `"current"`: highlight matches in the current buffer only
    -- * `"all"`: highlight matches in all visible buffers
    buffers = "filetype"
}
```
